### PR TITLE
Add codex launch setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ This is a **production-ready autonomous trading system** designed specifically f
 ```bash
 git clone https://github.com/yourusername/RTX-Trading-System.git
 cd RTX-Trading-System
-pip install -r requirements.txt
+# Install all dependencies and set up a virtual environment
+./codex_launch.sh
 ```
 
 ### 2. Configure Environment

--- a/codex_launch.sh
+++ b/codex_launch.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+# Codex launch script for AlgoSlayer
+# Sets up Python environment and installs all dependencies
+
+set -e
+
+# Create Python virtual environment
+python3 -m venv .venv
+source .venv/bin/activate
+
+# Upgrade pip
+pip install --upgrade pip setuptools wheel
+
+# Install system packages required for TA-Lib and other builds
+sudo apt-get update
+sudo apt-get install -y \
+  gcc g++ make wget curl git build-essential \
+  libssl-dev libffi-dev python3 python3-dev python3-venv python3-pip
+
+# Build and install TA-Lib (required by some technical analysis components)
+if ! python -c "import talib" 2>/dev/null; then
+    wget -q http://prdownloads.sourceforge.net/ta-lib/ta-lib-0.4.0-src.tar.gz
+    tar -xzf ta-lib-0.4.0-src.tar.gz
+    cd ta-lib
+    ./configure --prefix=/usr
+    make
+    sudo make install
+    cd ..
+    rm -rf ta-lib ta-lib-0.4.0-src.tar.gz
+fi
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+echo "\n✅ Environment setup complete. Activate with 'source .venv/bin/activate' and run 'python run_server.py'"
+


### PR DESCRIPTION
## Summary
- add `codex_launch.sh` for setting up a venv and installing dependencies
- document use of the new script in Quick Start section of README
- install python3, pip and venv packages when running setup script

## Testing
- `python test_accelerated_learning.py` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `python test_system_integration.py` *(fails: ModuleNotFoundError: No module named 'loguru')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'loguru')*


------
https://chatgpt.com/codex/tasks/task_b_68426b5809688331a987e350c208d482